### PR TITLE
Bump `num` version(s)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.1.2"
 authors = ["Meno Abels <meno.abels@adviser.com>"]
 
 [dependencies]
-num = "0.1.32"
-num-traits = "0.1.32"
-num-integer = "0.1.32"
-regex = "0.2.5"
+num = "0.2.1"
+num-traits = "0.2.11"
+num-integer = "0.1.42"
+regex = "1.7.3"
 libc = "0.2.15"
 lazy_static = "1.0.0"

--- a/rust/src/prefix32.rs
+++ b/rust/src/prefix32.rs
@@ -1,4 +1,3 @@
-
 use core::result::Result;
 
 #[allow(unused_variables)]
@@ -16,14 +15,13 @@ fn from(my: &::prefix::Prefix, num: usize) -> Result<::prefix::Prefix, String> {
 #[allow(unused_comparisons)]
 pub fn new(num: usize) -> Result<::prefix::Prefix, String> {
     if 0 <= num && num <= 32 {
-        //static _FROM: &'static (Fn(&::prefix::Prefix, usize) -> Result<::prefix::Prefix, String>) =
-            &from;
+        //static _FROM: &'static (Fn(&::prefix::Prefix, usize) -> Result<::prefix::Prefix, String>) = &from;
         //static _TO_IP_STR: &'static (Fn(&Vec<u16>) -> String) = &to_ip_str;
         let ip_bits = ::ip_bits::v4();
         let bits = ip_bits.bits;
         return Ok(::prefix::Prefix {
-            num: num,
-            ip_bits: ip_bits,
+            num,
+            ip_bits,
             net_mask: ::prefix::Prefix::new_netmask(num, bits),
             vt_from: from,
             //vt_to_ip_str: _TO_IP_STR,

--- a/rust/tests/test_ipv4.rs
+++ b/rust/tests/test_ipv4.rs
@@ -3,14 +3,14 @@ extern crate num;
 
 #[cfg(test)]
 mod tests {
+    use ipaddress::ipv4;
+    use ipaddress::IPAddress;
     use num::bigint::BigUint;
     use num::ToPrimitive;
-    use std::str::FromStr;
-    use ipaddress::IPAddress;
-    use ipaddress::ipv4;
     use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
     use std::ops::Deref;
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
 
     #[derive(Debug)]
     struct IPv4Prefix {
@@ -21,6 +21,7 @@ mod tests {
     struct IPv4Test {
         pub valid_ipv4: HashMap<&'static str, IPv4Prefix>,
         pub invalid_ipv4: Vec<&'static str>,
+        #[allow(dead_code)]
         pub valid_ipv4_range: Vec<&'static str>,
         pub netmask_values: HashMap<&'static str, &'static str>,
         pub decimal_values: HashMap<&'static str, u32>,
@@ -50,47 +51,65 @@ mod tests {
             class_c: ipv4::new("192.168.0.1/24").unwrap(),
             classful: HashMap::new(),
         };
-        ipv4t.valid_ipv4.insert("9.9/17",
-                                IPv4Prefix {
-                                    ip: String::from_str("9.0.0.9").unwrap(),
-                                    prefix: 17,
-                                });
-        ipv4t.valid_ipv4.insert("100.1.100",
-                                IPv4Prefix {
-                                    ip: String::from_str("100.1.0.100").unwrap(),
-                                    prefix: 32,
-                                });
-        ipv4t.valid_ipv4.insert("0.0.0.0/0",
-                                IPv4Prefix {
-                                    ip: String::from_str("0.0.0.0").unwrap(),
-                                    prefix: 0,
-                                });
-        ipv4t.valid_ipv4.insert("10.0.0.0",
-                                IPv4Prefix {
-                                    ip: String::from_str("10.0.0.0").unwrap(),
-                                    prefix: 32,
-                                });
-        ipv4t.valid_ipv4.insert("10.0.0.1",
-                                IPv4Prefix {
-                                    ip: String::from_str("10.0.0.1").unwrap(),
-                                    prefix: 32,
-                                });
-        ipv4t.valid_ipv4.insert("10.0.0.1/24",
-                                IPv4Prefix {
-                                    ip: String::from_str("10.0.0.1").unwrap(),
-                                    prefix: 24,
-                                });
-        ipv4t.valid_ipv4.insert("10.0.0.9/255.255.255.0",
-                                IPv4Prefix {
-                                    ip: String::from_str("10.0.0.9").unwrap(),
-                                    prefix: 24,
-                                });
+        ipv4t.valid_ipv4.insert(
+            "9.9/17",
+            IPv4Prefix {
+                ip: String::from_str("9.0.0.9").unwrap(),
+                prefix: 17,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "100.1.100",
+            IPv4Prefix {
+                ip: String::from_str("100.1.0.100").unwrap(),
+                prefix: 32,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "0.0.0.0/0",
+            IPv4Prefix {
+                ip: String::from_str("0.0.0.0").unwrap(),
+                prefix: 0,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "10.0.0.0",
+            IPv4Prefix {
+                ip: String::from_str("10.0.0.0").unwrap(),
+                prefix: 32,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "10.0.0.1",
+            IPv4Prefix {
+                ip: String::from_str("10.0.0.1").unwrap(),
+                prefix: 32,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "10.0.0.1/24",
+            IPv4Prefix {
+                ip: String::from_str("10.0.0.1").unwrap(),
+                prefix: 24,
+            },
+        );
+        ipv4t.valid_ipv4.insert(
+            "10.0.0.9/255.255.255.0",
+            IPv4Prefix {
+                ip: String::from_str("10.0.0.9").unwrap(),
+                prefix: 24,
+            },
+        );
 
         ipv4t.netmask_values.insert("0.0.0.0/0", "0.0.0.0");
         ipv4t.netmask_values.insert("10.0.0.0/8", "255.0.0.0");
         ipv4t.netmask_values.insert("172.16.0.0/16", "255.255.0.0");
-        ipv4t.netmask_values.insert("192.168.0.0/24", "255.255.255.0");
-        ipv4t.netmask_values.insert("192.168.100.4/30", "255.255.255.252");
+        ipv4t
+            .netmask_values
+            .insert("192.168.0.0/24", "255.255.255.0");
+        ipv4t
+            .netmask_values
+            .insert("192.168.100.4/30", "255.255.255.252");
 
         ipv4t.decimal_values.insert("0.0.0.0/0", 0);
         ipv4t.decimal_values.insert("10.0.0.0/8", 167772160);
@@ -104,12 +123,16 @@ mod tests {
         ipv4t.broadcast.insert("10.0.0.0/8", "10.255.255.255/8");
         ipv4t.broadcast.insert("172.16.0.0/16", "172.16.255.255/16");
         ipv4t.broadcast.insert("192.168.0.0/24", "192.168.0.255/24");
-        ipv4t.broadcast.insert("192.168.100.4/30", "192.168.100.7/30");
+        ipv4t
+            .broadcast
+            .insert("192.168.100.4/30", "192.168.100.7/30");
 
         ipv4t.networks.insert("10.5.4.3/8", "10.0.0.0/8");
         ipv4t.networks.insert("172.16.5.4/16", "172.16.0.0/16");
         ipv4t.networks.insert("192.168.4.3/24", "192.168.4.0/24");
-        ipv4t.networks.insert("192.168.100.5/30", "192.168.100.4/30");
+        ipv4t
+            .networks
+            .insert("192.168.100.5/30", "192.168.100.4/30");
 
         ipv4t.class_a = IPAddress::parse("10.0.0.1/8").unwrap();
         ipv4t.class_b = IPAddress::parse("172.16.0.1/16").unwrap();
@@ -120,7 +143,6 @@ mod tests {
         ipv4t.classful.insert("200.1.1.1", 24);
         return ipv4t;
     }
-
 
     #[test]
     pub fn test_initialize() {
@@ -240,17 +262,23 @@ mod tests {
         let ip = IPAddress::parse("10.0.0.1/29").unwrap();
         let arr = Arc::new(Mutex::new(Vec::new()));
         ip.each_host(|i| arr.lock().unwrap().push(i.to_s()));
-        assert_eq!(*arr.lock().unwrap().deref(),
-                   ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6"]);
+        assert_eq!(
+            *arr.lock().unwrap().deref(),
+            ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6"]
+        );
     }
     #[test]
     pub fn test_method_each() {
         let ip = IPAddress::parse("10.0.0.1/29").unwrap();
         let arr = Arc::new(Mutex::new(Vec::new()));
         ip.each(|i| arr.lock().unwrap().push(i.to_s()));
-        assert_eq!(*arr.lock().unwrap().deref(),
-                   ["10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5",
-                    "10.0.0.6", "10.0.0.7"]);
+        assert_eq!(
+            *arr.lock().unwrap().deref(),
+            [
+                "10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6",
+                "10.0.0.7"
+            ]
+        );
     }
     #[test]
     pub fn test_method_size() {
@@ -259,33 +287,43 @@ mod tests {
     }
     #[test]
     pub fn test_method_network_u32() {
-        assert_eq!(2886732288,
-                   setup().ip.network().host_address.to_u32().unwrap());
+        assert_eq!(
+            2886732288,
+            setup().ip.network().host_address.to_u32().unwrap()
+        );
     }
     #[test]
     pub fn test_method_broadcast_u32() {
-        assert_eq!(2886732543,
-                   setup().ip.broadcast().host_address.to_u32().unwrap());
+        assert_eq!(
+            2886732543,
+            setup().ip.broadcast().host_address.to_u32().unwrap()
+        );
     }
     #[test]
     pub fn test_method_include() {
         let mut ip = IPAddress::parse("192.168.10.100/24").unwrap();
         let addr = IPAddress::parse("192.168.10.102/24").unwrap();
         assert_eq!(true, ip.includes(&addr));
-        assert_eq!(false,
-                   ip.includes(&IPAddress::parse("172.16.0.48").unwrap()));
+        assert_eq!(
+            false,
+            ip.includes(&IPAddress::parse("172.16.0.48").unwrap())
+        );
         ip = IPAddress::parse("10.0.0.0/8").unwrap();
         assert_eq!(true, ip.includes(&IPAddress::parse("10.0.0.0/9").unwrap()));
         assert_eq!(true, ip.includes(&IPAddress::parse("10.1.1.1/32").unwrap()));
         assert_eq!(true, ip.includes(&IPAddress::parse("10.1.1.1/9").unwrap()));
-        assert_eq!(false,
-                   ip.includes(&IPAddress::parse("172.16.0.0/16").unwrap()));
+        assert_eq!(
+            false,
+            ip.includes(&IPAddress::parse("172.16.0.0/16").unwrap())
+        );
         assert_eq!(false, ip.includes(&IPAddress::parse("10.0.0.0/7").unwrap()));
         assert_eq!(false, ip.includes(&IPAddress::parse("5.5.5.5/32").unwrap()));
         assert_eq!(false, ip.includes(&IPAddress::parse("11.0.0.0/8").unwrap()));
         ip = IPAddress::parse("13.13.0.0/13").unwrap();
-        assert_eq!(false,
-                   ip.includes(&IPAddress::parse("13.16.0.0/32").unwrap()));
+        assert_eq!(
+            false,
+            ip.includes(&IPAddress::parse("13.16.0.0/32").unwrap())
+        );
     }
     #[test]
     pub fn test_method_include_all() {
@@ -293,8 +331,10 @@ mod tests {
         let addr1 = IPAddress::parse("192.168.10.102/24").unwrap();
         let addr2 = IPAddress::parse("192.168.10.103/24").unwrap();
         assert_eq!(true, ip.includes_all(&[addr1.clone(), addr2]));
-        assert_eq!(false,
-                   ip.includes_all(&[addr1, IPAddress::parse("13.16.0.0/32").unwrap()]));
+        assert_eq!(
+            false,
+            ip.includes_all(&[addr1, IPAddress::parse("13.16.0.0/32").unwrap()])
+        );
     }
     #[test]
     pub fn test_method_ipv4() {
@@ -306,29 +346,49 @@ mod tests {
     }
     #[test]
     pub fn test_method_private() {
-        assert_eq!(true,
-                   IPAddress::parse("169.254.10.50/24").unwrap().is_private());
-        assert_eq!(true,
-                   IPAddress::parse("192.168.10.50/24").unwrap().is_private());
-        assert_eq!(true,
-                   IPAddress::parse("192.168.10.50/16").unwrap().is_private());
-        assert_eq!(true,
-                   IPAddress::parse("172.16.77.40/24").unwrap().is_private());
-        assert_eq!(true,
-                   IPAddress::parse("172.16.10.50/14").unwrap().is_private());
-        assert_eq!(true,
-                   IPAddress::parse("10.10.10.10/10").unwrap().is_private());
+        assert_eq!(
+            true,
+            IPAddress::parse("169.254.10.50/24").unwrap().is_private()
+        );
+        assert_eq!(
+            true,
+            IPAddress::parse("192.168.10.50/24").unwrap().is_private()
+        );
+        assert_eq!(
+            true,
+            IPAddress::parse("192.168.10.50/16").unwrap().is_private()
+        );
+        assert_eq!(
+            true,
+            IPAddress::parse("172.16.77.40/24").unwrap().is_private()
+        );
+        assert_eq!(
+            true,
+            IPAddress::parse("172.16.10.50/14").unwrap().is_private()
+        );
+        assert_eq!(
+            true,
+            IPAddress::parse("10.10.10.10/10").unwrap().is_private()
+        );
         assert_eq!(true, IPAddress::parse("10.0.0.0/8").unwrap().is_private());
-        assert_eq!(false,
-                   IPAddress::parse("192.168.10.50/12").unwrap().is_private());
+        assert_eq!(
+            false,
+            IPAddress::parse("192.168.10.50/12").unwrap().is_private()
+        );
         assert_eq!(false, IPAddress::parse("3.3.3.3").unwrap().is_private());
         assert_eq!(false, IPAddress::parse("10.0.0.0/7").unwrap().is_private());
-        assert_eq!(false,
-                   IPAddress::parse("172.32.0.0/12").unwrap().is_private());
-        assert_eq!(false,
-                   IPAddress::parse("172.16.0.0/11").unwrap().is_private());
-        assert_eq!(false,
-                   IPAddress::parse("192.0.0.2/24").unwrap().is_private());
+        assert_eq!(
+            false,
+            IPAddress::parse("172.32.0.0/12").unwrap().is_private()
+        );
+        assert_eq!(
+            false,
+            IPAddress::parse("172.16.0.0/11").unwrap().is_private()
+        );
+        assert_eq!(
+            false,
+            IPAddress::parse("192.0.0.2/24").unwrap().is_private()
+        );
     }
     #[test]
     pub fn test_method_octet() {
@@ -365,33 +425,51 @@ mod tests {
     }
     #[test]
     pub fn test_method_dns_rev_domains() {
-        assert_eq!(IPAddress::parse("173.17.5.1/23").unwrap().dns_rev_domains(),
-                   ["4.17.173.in-addr.arpa", "5.17.173.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("173.17.1.1/15").unwrap().dns_rev_domains(),
-                   ["16.173.in-addr.arpa", "17.173.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("173.17.1.1/7").unwrap().dns_rev_domains(),
-                   ["172.in-addr.arpa", "173.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("173.17.1.1/29").unwrap().dns_rev_domains(),
-                   [
-                       "0.1.17.173.in-addr.arpa",
-                       "1.1.17.173.in-addr.arpa",
-                       "2.1.17.173.in-addr.arpa",
-                       "3.1.17.173.in-addr.arpa",
-                       "4.1.17.173.in-addr.arpa",
-                       "5.1.17.173.in-addr.arpa",
-                       "6.1.17.173.in-addr.arpa",
-                       "7.1.17.173.in-addr.arpa"
-                    ]);
-        assert_eq!(IPAddress::parse("174.17.1.1/24").unwrap().dns_rev_domains(),
-                   ["1.17.174.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("175.17.1.1/16").unwrap().dns_rev_domains(),
-                   ["17.175.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("176.17.1.1/8").unwrap().dns_rev_domains(),
-                   ["176.in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("177.17.1.1/0").unwrap().dns_rev_domains(),
-                   ["in-addr.arpa"]);
-        assert_eq!(IPAddress::parse("178.17.1.1/32").unwrap().dns_rev_domains(),
-                   ["1.1.17.178.in-addr.arpa"]);
+        assert_eq!(
+            IPAddress::parse("173.17.5.1/23").unwrap().dns_rev_domains(),
+            ["4.17.173.in-addr.arpa", "5.17.173.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("173.17.1.1/15").unwrap().dns_rev_domains(),
+            ["16.173.in-addr.arpa", "17.173.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("173.17.1.1/7").unwrap().dns_rev_domains(),
+            ["172.in-addr.arpa", "173.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("173.17.1.1/29").unwrap().dns_rev_domains(),
+            [
+                "0.1.17.173.in-addr.arpa",
+                "1.1.17.173.in-addr.arpa",
+                "2.1.17.173.in-addr.arpa",
+                "3.1.17.173.in-addr.arpa",
+                "4.1.17.173.in-addr.arpa",
+                "5.1.17.173.in-addr.arpa",
+                "6.1.17.173.in-addr.arpa",
+                "7.1.17.173.in-addr.arpa"
+            ]
+        );
+        assert_eq!(
+            IPAddress::parse("174.17.1.1/24").unwrap().dns_rev_domains(),
+            ["1.17.174.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("175.17.1.1/16").unwrap().dns_rev_domains(),
+            ["17.175.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("176.17.1.1/8").unwrap().dns_rev_domains(),
+            ["176.in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("177.17.1.1/0").unwrap().dns_rev_domains(),
+            ["in-addr.arpa"]
+        );
+        assert_eq!(
+            IPAddress::parse("178.17.1.1/32").unwrap().dns_rev_domains(),
+            ["1.1.17.178.in-addr.arpa"]
+        );
     }
     #[test]
     pub fn test_method_compare() {
@@ -418,8 +496,10 @@ mod tests {
         // test sorting
         let mut res = [ip1, ip2, ip3];
         res.sort();
-        assert_eq!(IPAddress::to_string_vec(&res.to_vec()),
-                   ["10.1.1.1/8", "10.1.1.1/16", "172.16.1.1/14"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&res.to_vec()),
+            ["10.1.1.1/8", "10.1.1.1/16", "172.16.1.1/14"]
+        );
         // test same prefix
         ip1 = IPAddress::parse("10.0.0.0/24").unwrap();
         ip2 = IPAddress::parse("10.0.0.0/16").unwrap();
@@ -427,8 +507,10 @@ mod tests {
         {
             let mut res = [ip1, ip2, ip3];
             res.sort();
-            assert_eq!(IPAddress::to_string_vec(&res.to_vec()),
-                       ["10.0.0.0/8", "10.0.0.0/16", "10.0.0.0/24"]);
+            assert_eq!(
+                IPAddress::to_string_vec(&res.to_vec()),
+                ["10.0.0.0/8", "10.0.0.0/16", "10.0.0.0/24"]
+            );
         }
     }
     #[test]
@@ -445,18 +527,24 @@ mod tests {
         assert_eq!(IPAddress::to_string_vec(&ip1.add(&ip2)), ["172.16.10.0/23"]);
 
         ip2 = IPAddress::parse("172.16.12.2/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&ip1.add(&ip2)),
-                   [ip1.network().to_string(), ip2.network().to_string()]);
+        assert_eq!(
+            IPAddress::to_string_vec(&ip1.add(&ip2)),
+            [ip1.network().to_string(), ip2.network().to_string()]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&ip1.add(&ip2)),
-                   ["10.0.0.0/23", "10.0.2.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&ip1.add(&ip2)),
+            ["10.0.0.0/23", "10.0.2.0/24"]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&ip1.add(&ip2)),
-                   ["10.0.0.0/23", "10.0.2.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&ip1.add(&ip2)),
+            ["10.0.0.0/23", "10.0.2.0/24"]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/16").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/24").unwrap();
@@ -464,8 +552,10 @@ mod tests {
 
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.1.0.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&ip1.add(&ip2)),
-                   ["10.0.0.0/23", "10.1.0.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&ip1.add(&ip2)),
+            ["10.0.0.0/23", "10.1.0.0/24"]
+        );
     }
     #[test]
     pub fn test_method_netmask_equal() {
@@ -481,78 +571,121 @@ mod tests {
 
         assert_eq!(setup().ip.split(1).unwrap(), [setup().ip.network()]);
 
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(8).unwrap()),
-                   ["172.16.10.0/27",
-                    "172.16.10.32/27",
-                    "172.16.10.64/27",
-                    "172.16.10.96/27",
-                    "172.16.10.128/27",
-                    "172.16.10.160/27",
-                    "172.16.10.192/27",
-                    "172.16.10.224/27"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(8).unwrap()),
+            [
+                "172.16.10.0/27",
+                "172.16.10.32/27",
+                "172.16.10.64/27",
+                "172.16.10.96/27",
+                "172.16.10.128/27",
+                "172.16.10.160/27",
+                "172.16.10.192/27",
+                "172.16.10.224/27"
+            ]
+        );
 
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(7).unwrap()),
-                   ["172.16.10.0/27",
-                    "172.16.10.32/27",
-                    "172.16.10.64/27",
-                    "172.16.10.96/27",
-                    "172.16.10.128/27",
-                    "172.16.10.160/27",
-                    "172.16.10.192/26"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(7).unwrap()),
+            [
+                "172.16.10.0/27",
+                "172.16.10.32/27",
+                "172.16.10.64/27",
+                "172.16.10.96/27",
+                "172.16.10.128/27",
+                "172.16.10.160/27",
+                "172.16.10.192/26"
+            ]
+        );
 
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(6).unwrap()),
-                   ["172.16.10.0/27",
-                    "172.16.10.32/27",
-                    "172.16.10.64/27",
-                    "172.16.10.96/27",
-                    "172.16.10.128/26",
-                    "172.16.10.192/26"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(5).unwrap()),
-                   ["172.16.10.0/27",
-                    "172.16.10.32/27",
-                    "172.16.10.64/27",
-                    "172.16.10.96/27",
-                    "172.16.10.128/25"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(4).unwrap()),
-                   ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/26", "172.16.10.192/26"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(3).unwrap()),
-                   ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/25"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(2).unwrap()),
-                   ["172.16.10.0/25", "172.16.10.128/25"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.split(1).unwrap()),
-                   ["172.16.10.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(6).unwrap()),
+            [
+                "172.16.10.0/27",
+                "172.16.10.32/27",
+                "172.16.10.64/27",
+                "172.16.10.96/27",
+                "172.16.10.128/26",
+                "172.16.10.192/26"
+            ]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(5).unwrap()),
+            [
+                "172.16.10.0/27",
+                "172.16.10.32/27",
+                "172.16.10.64/27",
+                "172.16.10.96/27",
+                "172.16.10.128/25"
+            ]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(4).unwrap()),
+            [
+                "172.16.10.0/26",
+                "172.16.10.64/26",
+                "172.16.10.128/26",
+                "172.16.10.192/26"
+            ]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(3).unwrap()),
+            ["172.16.10.0/26", "172.16.10.64/26", "172.16.10.128/25"]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(2).unwrap()),
+            ["172.16.10.0/25", "172.16.10.128/25"]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.split(1).unwrap()),
+            ["172.16.10.0/24"]
+        );
     }
     #[test]
     pub fn test_method_subnet() {
         assert!(setup().network.subnet(23).is_err());
         assert!(setup().network.subnet(33).is_err());
         assert!(setup().ip.subnet(30).is_ok());
-        assert_eq!(IPAddress::to_string_vec(&setup().network.subnet(26).unwrap()),
-                                 ["172.16.10.0/26",
-                                  "172.16.10.64/26",
-                                  "172.16.10.128/26",
-                                  "172.16.10.192/26"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.subnet(25).unwrap()),
-                   ["172.16.10.0/25", "172.16.10.128/25"]);
-        assert_eq!(IPAddress::to_string_vec(&setup().network.subnet(24).unwrap()),
-                   ["172.16.10.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.subnet(26).unwrap()),
+            [
+                "172.16.10.0/26",
+                "172.16.10.64/26",
+                "172.16.10.128/26",
+                "172.16.10.192/26"
+            ]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.subnet(25).unwrap()),
+            ["172.16.10.0/25", "172.16.10.128/25"]
+        );
+        assert_eq!(
+            IPAddress::to_string_vec(&setup().network.subnet(24).unwrap()),
+            ["172.16.10.0/24"]
+        );
     }
     #[test]
     pub fn test_method_supernet() {
         assert!(setup().ip.supernet(24).is_err());
         assert_eq!("0.0.0.0/0", setup().ip.supernet(0).unwrap().to_string());
         // assert_eq!("0.0.0.0/0", setup().ip.supernet(-2).unwrap().to_string());
-        assert_eq!("172.16.10.0/23",
-                   setup().ip.supernet(23).unwrap().to_string());
-        assert_eq!("172.16.8.0/22",
-                   setup().ip.supernet(22).unwrap().to_string());
+        assert_eq!(
+            "172.16.10.0/23",
+            setup().ip.supernet(23).unwrap().to_string()
+        );
+        assert_eq!(
+            "172.16.8.0/22",
+            setup().ip.supernet(22).unwrap().to_string()
+        );
     }
     #[test]
     pub fn test_classmethod_parse_u32() {
         for (addr, int) in setup().decimal_values {
             let ip = ipv4::from_u32(int, 32).unwrap();
             let splitted: Vec<&str> = addr.split("/").collect();
-            let ip2 = ip.change_prefix(splitted[1].parse::<usize>().unwrap()).unwrap();
+            let ip2 = ip
+                .change_prefix(splitted[1].parse::<usize>().unwrap())
+                .unwrap();
             assert_eq!(ip2.to_string(), addr);
         }
     }
@@ -563,94 +696,127 @@ mod tests {
     // }
     #[test]
     pub fn test_classmethod_summarize() {
-
         // Should return self if only one network given
-        assert_eq!(IPAddress::summarize(&vec![setup().ip]),
-                   [setup().ip.network()]);
+        assert_eq!(
+            IPAddress::summarize(&vec![setup().ip]),
+            [setup().ip.network()]
+        );
 
         // Summarize homogeneous networks
         let mut ip1 = IPAddress::parse("172.16.10.1/24").unwrap();
         let mut ip2 = IPAddress::parse("172.16.11.2/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
-                   ["172.16.10.0/23"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
+            ["172.16.10.0/23"]
+        );
 
         {
             let ip1 = IPAddress::parse("10.0.0.1/24").unwrap();
             let ip2 = IPAddress::parse("10.0.1.1/24").unwrap();
             let ip3 = IPAddress::parse("10.0.2.1/24").unwrap();
             let ip4 = IPAddress::parse("10.0.3.1/24").unwrap();
-            assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
-                       ["10.0.0.0/22"]);
+            assert_eq!(
+                IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
+                ["10.0.0.0/22"]
+            );
         }
         {
             let ip1 = IPAddress::parse("10.0.0.1/24").unwrap();
             let ip2 = IPAddress::parse("10.0.1.1/24").unwrap();
             let ip3 = IPAddress::parse("10.0.2.1/24").unwrap();
             let ip4 = IPAddress::parse("10.0.3.1/24").unwrap();
-            assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip4, ip3, ip2, ip1])),
-                       ["10.0.0.0/22"]);
+            assert_eq!(
+                IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip4, ip3, ip2, ip1])),
+                ["10.0.0.0/22"]
+            );
         }
 
         // Summarize non homogeneous networks
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
-                   ["10.0.0.0/23", "10.0.2.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
+            ["10.0.0.0/23", "10.0.2.0/24"]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/16").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
-                   ["10.0.0.0/16"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
+            ["10.0.0.0/16"]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.1.0.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
-                   ["10.0.0.0/23", "10.1.0.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2])),
+            ["10.0.0.0/23", "10.1.0.0/24"]
+        );
 
         ip1 = IPAddress::parse("10.0.0.0/23").unwrap();
         ip2 = IPAddress::parse("10.0.2.0/23").unwrap();
         let mut ip3 = IPAddress::parse("10.0.4.0/24").unwrap();
         let mut ip4 = IPAddress::parse("10.0.6.0/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
-                   ["10.0.0.0/22", "10.0.4.0/24", "10.0.6.0/24"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
+            ["10.0.0.0/22", "10.0.4.0/24", "10.0.6.0/24"]
+        );
         {
             let ip1 = IPAddress::parse("10.0.1.1/24").unwrap();
             let ip2 = IPAddress::parse("10.0.2.1/24").unwrap();
             let ip3 = IPAddress::parse("10.0.3.1/24").unwrap();
             let ip4 = IPAddress::parse("10.0.4.1/24").unwrap();
-            assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
-                       ["10.0.1.0/24", "10.0.2.0/23", "10.0.4.0/24"]);
+            assert_eq!(
+                IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
+                ["10.0.1.0/24", "10.0.2.0/23", "10.0.4.0/24"]
+            );
         }
         {
             let ip1 = IPAddress::parse("10.0.1.1/24").unwrap();
             let ip2 = IPAddress::parse("10.0.2.1/24").unwrap();
             let ip3 = IPAddress::parse("10.0.3.1/24").unwrap();
             let ip4 = IPAddress::parse("10.0.4.1/24").unwrap();
-            assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip4, ip3, ip2, ip1])),
-                       ["10.0.1.0/24", "10.0.2.0/23", "10.0.4.0/24"]);
+            assert_eq!(
+                IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip4, ip3, ip2, ip1])),
+                ["10.0.1.0/24", "10.0.2.0/23", "10.0.4.0/24"]
+            );
         }
 
         ip1 = IPAddress::parse("10.0.1.1/24").unwrap();
         ip2 = IPAddress::parse("10.10.2.1/24").unwrap();
         ip3 = IPAddress::parse("172.16.0.1/24").unwrap();
         ip4 = IPAddress::parse("172.16.1.1/24").unwrap();
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
-                   ["10.0.1.0/24", "10.10.2.0/24", "172.16.0.0/23"]);
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&vec![ip1, ip2, ip3, ip4])),
+            ["10.0.1.0/24", "10.10.2.0/24", "172.16.0.0/23"]
+        );
 
-        let mut ips = vec![IPAddress::parse("10.0.0.12/30").unwrap(),
-                           IPAddress::parse("10.0.100.0/24").unwrap()];
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
-                   ["10.0.0.12/30", "10.0.100.0/24"]);
+        let mut ips = vec![
+            IPAddress::parse("10.0.0.12/30").unwrap(),
+            IPAddress::parse("10.0.100.0/24").unwrap(),
+        ];
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
+            ["10.0.0.12/30", "10.0.100.0/24"]
+        );
 
-        ips = vec![IPAddress::parse("172.16.0.0/31").unwrap(),
-                   IPAddress::parse("10.10.2.1/32").unwrap()];
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
-                   ["10.10.2.1/32", "172.16.0.0/31"]);
+        ips = vec![
+            IPAddress::parse("172.16.0.0/31").unwrap(),
+            IPAddress::parse("10.10.2.1/32").unwrap(),
+        ];
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
+            ["10.10.2.1/32", "172.16.0.0/31"]
+        );
 
-        ips = vec![IPAddress::parse("172.16.0.0/32").unwrap(),
-                   IPAddress::parse("10.10.2.1/32").unwrap()];
-        assert_eq!(IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
-                   ["10.10.2.1/32", "172.16.0.0/32"]);
+        ips = vec![
+            IPAddress::parse("172.16.0.0/32").unwrap(),
+            IPAddress::parse("10.10.2.1/32").unwrap(),
+        ];
+        assert_eq!(
+            IPAddress::to_string_vec(&IPAddress::summarize(&ips)),
+            ["10.10.2.1/32", "172.16.0.0/32"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
PR bumps the pinned version(s) of [`num`](https://github.com/rust-num/num) to silence warnings from rustc about future incompatibility explained [here](https://github.com/rust-num/num/issues/424).